### PR TITLE
Add Webring Links

### DIFF
--- a/source/index.html.haml
+++ b/source/index.html.haml
@@ -4,7 +4,9 @@ description: Adarsh Pandit's Blog - Ruby, Rails, JavaScript, Detroit, Life
 ---
 
 %h1
+  =link_to('←', 'http://alexfox.me', title: 'Yes, this is a webring')
   =link_to('Adarsh Pandit', '/')
+  =link_to('→', 'http://gabebw.com', title: 'Yes, this is a webring')
 %h3{class: 'tagline'}
   Ruby Developer
 


### PR DESCRIPTION
Reason for change:
* Be in a webring for old-times-sake

What the change was:
* Add links to the other two members of the webring as arrows
* Add `title` attributes to give some mouseover information

![image](https://cloud.githubusercontent.com/assets/913757/10933372/d6659632-828c-11e5-8c73-33f08672421d.png)
