### PR TITLE
Add footer with link to RSS Feed

### DIFF
--- a/source/layouts/footer.html.haml
+++ b/source/layouts/footer.html.haml
@@ -1,0 +1,3 @@
+= link_to('RSS Feed', '/feed.xml')
+|
+= link_to('@adarshp', 'https://twitter.com/adarshp')

--- a/source/layouts/layout.html.haml
+++ b/source/layouts/layout.html.haml
@@ -6,6 +6,7 @@
   %meta{name:'description', content: data.page.description}
 
   %title= current_page.data.title || settings.site_name
+  %link{href: 'feed.xml', rel: 'alternate', title: 'RSS', type: 'application/rss+xml'}
 
   = stylesheet_link_tag 'application'
 
@@ -16,3 +17,4 @@
   .container
     = yield
   .footer
+    = partial('layouts/footer')

--- a/source/stylesheets/_layout.scss
+++ b/source/stylesheets/_layout.scss
@@ -266,3 +266,10 @@ blockquote {
     white-space: pre-wrap;
   }
 }
+
+.footer {
+  display: block;
+  font-style: italic;
+  padding-bottom: 10em;
+  text-align: center;
+}


### PR DESCRIPTION
Reason for change:
* No one could find the RSS Feed
* There was also no footer

What the change was:
* Add a footer partial with links
* Style the footer

![image](https://cloud.githubusercontent.com/assets/913757/11050596/55a4f8c0-86fc-11e5-9f5e-d4fbff9fa163.png)
