### PR TITLE
Move the GA tracking code to the <HEAD>

### DIFF
--- a/source/layouts/footer.html.haml
+++ b/source/layouts/footer.html.haml
@@ -1,5 +1,3 @@
 = link_to('RSS Feed', '/feed.xml')
 |
 = link_to('@adarshp', 'https://twitter.com/adarshp')
-
-= google_analytics_universal_tag

--- a/source/layouts/layout.html.haml
+++ b/source/layouts/layout.html.haml
@@ -13,6 +13,8 @@
   - if current_page.data.author
     %link{href: 'https://plus.google.com/116006351214905134217', rel:'author'}
 
+  = google_analytics_universal_tag
+
 %body
   .container
     = yield


### PR DESCRIPTION
Reason for change:
* Google hates that this wasn't in the <HEAD> tag

What the change was:
* Move it to the <HEAD>