### PR TITLE
Automatically add alt attributes to images

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -35,6 +35,7 @@ activate :deploy do |deploy|
   deploy.branch  = 'master'
 end
 
+activate :automatic_alt_tags
 activate :automatic_image_sizes
 activate :directory_indexes
 activate :livereload


### PR DESCRIPTION
Reason for change:
* More SEO juice

What the change was:
* Activate `automatic_alt_tags` in `config.rb`