### PR TITLE
Fix broken link in Growing Devs post

### DIFF
--- a/source/articles/2016/on-growing-great-developers.html.md
+++ b/source/articles/2016/on-growing-great-developers.html.md
@@ -22,7 +22,7 @@ If you want help setting up a program like this, [email me](mailto:hi@cylinder.w
 
 
 ![apprenticeship](apprenticeship.png)
-  _photo courtesy of WOCinTech ([wocintechchat.com](wocintechchat.com))_
+  _photo courtesy of WOCinTech ([wocintechchat.com](http://www.wocintechchat.com?utm_source=adarsh.io&utm_medium=blog))_
 
 ### Why Steal
 


### PR DESCRIPTION
Reason for Change
=================
* I failed to add the `http://` part of the URL and the link wouldn't work.

Changes
=======
* Add the protocol.
* Add some `utm` tags.