### PR TITLE
Correct error in memoization post

### DIFF
--- a/source/articles/2016/use-an-underscore-when-memoizing-in-ruby.html.md
+++ b/source/articles/2016/use-an-underscore-when-memoizing-in-ruby.html.md
@@ -110,7 +110,7 @@ when memoizing in Rails controllers:
 > private
 >
 > def users
->   @_users = User.all
+>   @_users ||= User.all
 > end
 > ```
 


### PR DESCRIPTION
# Reason for Change
- Astute Twitter Friend [@seancookr](https://twitter.com/seancookr/status/789211149363351552) noted [I forgot to memoize the controller private method](https://twitter.com/seancookr) in my example. Whoops!
# Changes
- Memoize it!
# Acknowledgements
- Thanks to @seancookr for the erratum!
